### PR TITLE
Feature: reusable cells

### DIFF
--- a/Pod/Wall.xcodeproj/project.pbxproj
+++ b/Pod/Wall.xcodeproj/project.pbxproj
@@ -30,7 +30,6 @@
 		14C136521AB784B200B7B07A /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CONTRIBUTING.md; path = ../CONTRIBUTING.md; sourceTree = "<group>"; };
 		14C136541AB784B200B7B07A /* LICENSE.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = LICENSE.md; path = ../LICENSE.md; sourceTree = "<group>"; };
 		14C136551AB784B200B7B07A /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		14C1365C1AB784BC00B7B07A /* .gitkeep */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		6002B75869AABDFDCC4F755D /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		D513B1621BEB54FE003142EE /* PostTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostTableViewCell.swift; sourceTree = "<group>"; };
 		D513B1641BEB54FE003142EE /* Author.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Author.swift; sourceTree = "<group>"; };
@@ -114,7 +113,6 @@
 				D513B1631BEB54FE003142EE /* Models */,
 				D513B1661BEB54FE003142EE /* Views */,
 				D513B16B1BEB54FE003142EE /* WallController.swift */,
-				14C1365C1AB784BC00B7B07A /* .gitkeep */,
 			);
 			name = Source;
 			path = ../Source;

--- a/Pod/Wall.xcodeproj/project.pbxproj
+++ b/Pod/Wall.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		D513B1721BEB54FE003142EE /* PostInformationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D513B16A1BEB54FE003142EE /* PostInformationBarView.swift */; };
 		D513B1731BEB54FE003142EE /* WallController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D513B16B1BEB54FE003142EE /* WallController.swift */; };
 		D513B1751BEB5ED6003142EE /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = D513B1741BEB5ED6003142EE /* Media.swift */; settings = {ASSET_TAGS = (); }; };
+		D513B1771BEB910E003142EE /* WallTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D513B1761BEB910E003142EE /* WallTableViewCell.swift */; settings = {ASSET_TAGS = (); }; };
 		EEB30432F816C5C40A477F1A /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA2FED9C3FB1E8B9DE89C3C7 /* Pods.framework */; };
 /* End PBXBuildFile section */
 
@@ -40,6 +41,7 @@
 		D513B16A1BEB54FE003142EE /* PostInformationBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostInformationBarView.swift; sourceTree = "<group>"; };
 		D513B16B1BEB54FE003142EE /* WallController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallController.swift; sourceTree = "<group>"; };
 		D513B1741BEB5ED6003142EE /* Media.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Media.swift; sourceTree = "<group>"; };
+		D513B1761BEB910E003142EE /* WallTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallTableViewCell.swift; sourceTree = "<group>"; };
 		FA2FED9C3FB1E8B9DE89C3C7 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -129,6 +131,7 @@
 		D513B1611BEB54FE003142EE /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				D513B1761BEB910E003142EE /* WallTableViewCell.swift */,
 				D513B1621BEB54FE003142EE /* PostTableViewCell.swift */,
 			);
 			path = Cells;
@@ -286,6 +289,7 @@
 				D513B1731BEB54FE003142EE /* WallController.swift in Sources */,
 				D513B1711BEB54FE003142EE /* PostMediaView.swift in Sources */,
 				D513B16D1BEB54FE003142EE /* Author.swift in Sources */,
+				D513B1771BEB910E003142EE /* WallTableViewCell.swift in Sources */,
 				D513B16F1BEB54FE003142EE /* PostActionBarView.swift in Sources */,
 				D513B1751BEB5ED6003142EE /* Media.swift in Sources */,
 				D513B1721BEB54FE003142EE /* PostInformationBarView.swift in Sources */,

--- a/Source/Cells/PostTableViewCell.swift
+++ b/Source/Cells/PostTableViewCell.swift
@@ -19,7 +19,21 @@ public protocol PostInformationDelegate: class {
   func authorDidTap(postID: Int)
 }
 
-public class PostTableViewCell: UITableViewCell {
+public class WallTableViewCell: UITableViewCell {
+
+  public var post: Post?
+  public weak var delegate: PostTableViewCellDelegate?
+
+
+  public func configureCell(post: Post) {
+    self.post = post
+  }
+}
+
+public class PostTableViewCell: WallTableViewCell {
+
+  public weak var actionDelegate: PostActionDelegate?
+  public weak var informationDelegate: PostInformationDelegate?
 
   public static let reusableIdentifier = "PostTableViewCell"
 
@@ -73,11 +87,6 @@ public class PostTableViewCell: UITableViewCell {
 
     return layer
     }()
-
-  public weak var delegate: PostTableViewCellDelegate?
-  public weak var actionDelegate: PostActionDelegate?
-  public weak var informationDelegate: PostInformationDelegate?
-  public var post: Post?
 
   // MARK: - Initialization
 
@@ -142,10 +151,6 @@ public class PostTableViewCell: UITableViewCell {
     informationView.frame.origin = CGPoint(x: 0, y: CGRectGetMaxY(postText.frame))
     actionBarView.frame.origin = CGPoint(x: 0, y: CGRectGetMaxY(informationView.frame))
     bottomSeparator.frame.origin.y = CGRectGetMaxY(actionBarView.frame)
-  }
-
-  public func configureCell(post: Post) {
-    self.post = post
   }
 }
 

--- a/Source/Cells/PostTableViewCell.swift
+++ b/Source/Cells/PostTableViewCell.swift
@@ -1,10 +1,5 @@
 import UIKit
 
-public protocol PostTableViewCellDelegate: class {
-
-  func updateCellSize(postID: Int)
-}
-
 public protocol PostActionDelegate: class {
 
   func likeButtonDidPress(postID: Int)
@@ -17,17 +12,6 @@ public protocol PostInformationDelegate: class {
   func commentsInformationDidPress(postID: Int)
   func seenInformationDidPress(postID: Int)
   func authorDidTap(postID: Int)
-}
-
-public class WallTableViewCell: UITableViewCell {
-
-  public var post: Post?
-  public weak var delegate: PostTableViewCellDelegate?
-
-
-  public func configureCell(post: Post) {
-    self.post = post
-  }
 }
 
 public class PostTableViewCell: WallTableViewCell {

--- a/Source/Cells/WallTableViewCell.swift
+++ b/Source/Cells/WallTableViewCell.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+public protocol WallTableViewCellDelegate: class {
+
+  func updateCellSize(postID: Int)
+}
+
+public class WallTableViewCell: UITableViewCell {
+
+  public var post: Post?
+  public weak var delegate: WallTableViewCellDelegate?
+
+  public func configureCell(post: Post) {
+    self.post = post
+  }
+}

--- a/Source/Models/Post.swift
+++ b/Source/Models/Post.swift
@@ -16,18 +16,20 @@ public class Post {
   public var seenCount = 0
   public var commentCount = 0
   public var author: Author?
+  public var reusableIdentifier: String?
 
   public var media: [Media]
 
   // MARK: - Initialization
 
-  public init(id: Int, text: String = "", publishDate: String,
-    author: Author? = nil, media: [Media] = []) {
+  public init(id: Int, text: String = "", publishDate: String, author: Author? = nil,
+    media: [Media] = [], reusableIdentifier: String? = nil) {
       self.id = id
       self.text = text
       self.publishDate = publishDate
       self.author = author
       self.media = media
+      self.reusableIdentifier = reusableIdentifier
   }
 }
 

--- a/Source/WallController.swift
+++ b/Source/WallController.swift
@@ -203,7 +203,6 @@ extension WallController: UITableViewDataSource {
     cell.configureCell(post)
     cell.delegate = self
 
-
     return cell
   }
 }

--- a/Source/WallController.swift
+++ b/Source/WallController.swift
@@ -126,9 +126,9 @@ public class WallController: UIViewController {
   }
 }
 
-// MARK: - PostTableViewCellDelegate
+// MARK: - WallTableViewCellDelegate
 
-extension WallController: PostTableViewCellDelegate {
+extension WallController: WallTableViewCellDelegate {
 
   public func updateCellSize(postID: Int) {
     tableView.beginUpdates()

--- a/Source/WallController.swift
+++ b/Source/WallController.swift
@@ -8,8 +8,6 @@ public protocol WallControllerDelegate: class {
 
 public class WallController: UIViewController {
 
-  public static var cells = [String: UITableViewCell.Type]()
-
   public lazy var tableView: UITableView = { [unowned self] in
     let tableView = UITableView()
     tableView.delegate = self
@@ -86,7 +84,7 @@ public class WallController: UIViewController {
 
   // MARK: - Configuration
 
-  public func registerCell<T: UITableViewCell>(cellClass: T.Type, reusableIdentifier: String) {
+  public func registerCell<T: WallTableViewCell>(cellClass: T.Type, reusableIdentifier: String) {
     tableView.registerClass(cellClass,
       forCellReuseIdentifier: reusableIdentifier)
   }
@@ -188,15 +186,23 @@ extension WallController: UITableViewDataSource {
   }
 
   public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-    guard let cell = tableView.dequeueReusableCellWithIdentifier(PostTableViewCell.reusableIdentifier)
-      as? PostTableViewCell else { return PostTableViewCell() }
-
     let post = posts[indexPath.row]
+    var wallCell: WallTableViewCell?
+
+    if let reusableIdentifier = post.reusableIdentifier,
+      registeredCell = tableView.dequeueReusableCellWithIdentifier(reusableIdentifier) as? WallTableViewCell {
+        wallCell = registeredCell
+    } else if let postCell = tableView.dequeueReusableCellWithIdentifier(PostTableViewCell.reusableIdentifier) as? PostTableViewCell {
+      postCell.actionDelegate = actionDelegate
+      postCell.informationDelegate = informationDelegate
+      wallCell = postCell
+    }
+
+    guard let cell = wallCell else { return PostTableViewCell() }
 
     cell.configureCell(post)
     cell.delegate = self
-    cell.actionDelegate = actionDelegate
-    cell.informationDelegate = informationDelegate
+
 
     return cell
   }

--- a/Source/WallController.swift
+++ b/Source/WallController.swift
@@ -8,6 +8,8 @@ public protocol WallControllerDelegate: class {
 
 public class WallController: UIViewController {
 
+  public static var cells = [String: UITableViewCell.Type]()
+
   public lazy var tableView: UITableView = { [unowned self] in
     let tableView = UITableView()
     tableView.registerClass(PostTableViewCell.self,

--- a/Source/WallController.swift
+++ b/Source/WallController.swift
@@ -12,8 +12,6 @@ public class WallController: UIViewController {
 
   public lazy var tableView: UITableView = { [unowned self] in
     let tableView = UITableView()
-    tableView.registerClass(PostTableViewCell.self,
-      forCellReuseIdentifier: PostTableViewCell.reusableIdentifier)
     tableView.delegate = self
     tableView.dataSource = self
     tableView.frame = CGRect(x: 0, y: 0,
@@ -67,6 +65,9 @@ public class WallController: UIViewController {
     tableView.sendSubviewToBack(refreshControl)
     refreshControl.subviews.first?.frame.origin.y = -5
 
+    registerCell(PostTableViewCell.self,
+      reusableIdentifier: PostTableViewCell.reusableIdentifier)
+
     view.backgroundColor = UIColor.whiteColor()
     view.layer.opaque = true
 
@@ -84,6 +85,11 @@ public class WallController: UIViewController {
   }
 
   // MARK: - Configuration
+
+  public func registerCell<T: UITableViewCell>(cellClass: T.Type, reusableIdentifier: String) {
+    tableView.registerClass(cellClass,
+      forCellReuseIdentifier: reusableIdentifier)
+  }
 
   public func initializePosts(newPosts: [PostConvertible]) {
     posts = []


### PR DESCRIPTION
@RamonGilabert 
So now we have:
1) Base cell `WallTableViewCell` you should inherit from to get everything for free.
2) `registerCell` func that makes it super easy to register your WallTableViewCell-based class.
3) Then we try to get `reusableIdentifier` from the Post, `PostTableViewCell` is a default cell we use in our data source.
