### PR TITLE
Fix configure comment cell

### DIFF
--- a/Source/Cells/CommentTableViewCell.swift
+++ b/Source/Cells/CommentTableViewCell.swift
@@ -127,6 +127,8 @@ public class CommentTableViewCell: WallTableViewCell {
   }
 
   public override func configureCell(post: Post) {
+    super.configureCell(post)
+
     guard let author = post.author else { return }
     let totalWidth = UIScreen.mainScreen().bounds.width
 


### PR DESCRIPTION
@RamonGilabert We never set the post to the comment cell, so delegate methods have never been called.
